### PR TITLE
Linter ADR: Laravel Backend Code Standards (php-cs-fixer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 /.idea
 /.vscode
 /.editorconfig
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,247 @@
+<?php
+
+use App\Fixers;
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+// Source
+// https://github.com/laravel/pint/blob/main/resources/presets/laravel.php
+$rules = [
+    'array_indentation' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+    ],
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'blank_line_before_statement' => [
+        'statements' => [
+            'continue',
+            'return',
+        ],
+    ],
+    'blank_line_between_import_groups' => true,
+    'blank_lines_before_namespace' => true,
+    'braces_position' => [
+        'control_structures_opening_brace' => 'same_line',
+        'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'anonymous_functions_opening_brace' => 'same_line',
+        'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'anonymous_classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'allow_single_line_empty_anonymous_classes' => false,
+        'allow_single_line_anonymous_functions' => false,
+    ],
+    'cast_spaces' => true,
+    'class_attributes_separation' => [
+        'elements' => [
+            'const' => 'one',
+            'method' => 'one',
+            'property' => 'one',
+            'trait_import' => 'none',
+        ],
+    ],
+    'class_definition' => [
+        'multi_line_extends_each_single_line' => true,
+        'single_item_single_line' => true,
+        'single_line' => true,
+    ],
+    'clean_namespace' => true,
+    'compact_nullable_type_declaration' => true,
+    'concat_space' => [
+        'spacing' => 'none',
+    ],
+    'constant_case' => ['case' => 'lower'],
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => [
+        'position' => 'same_line',
+    ],
+    'declare_equal_normalize' => true,
+    'declare_parentheses' => true,
+    'elseif' => true,
+    'encoding' => true,
+    'full_opening_tag' => true,
+    'fully_qualified_strict_types' => false,
+    'function_declaration' => true,
+    'general_phpdoc_tag_rename' => true,
+    'heredoc_to_nowdoc' => true,
+    'include' => true,
+    'increment_style' => ['style' => 'post'],
+    'indentation_type' => true,
+    'integer_literal_case' => true,
+    'lambda_not_used_import' => true,
+    'line_ending' => true,
+    'linebreak_after_opening_tag' => true,
+    'list_syntax' => true,
+    'lowercase_cast' => true,
+    'lowercase_keywords' => true,
+    'lowercase_static_reference' => true,
+    'magic_constant_casing' => true,
+    'magic_method_casing' => true,
+    'method_argument_space' => [
+        'on_multiline' => 'ignore',
+    ],
+    'method_chaining_indentation' => true,
+    'multiline_whitespace_before_semicolons' => [
+        'strategy' => 'no_multi_line',
+    ],
+    'native_function_casing' => true,
+    'native_type_declaration_casing' => true,
+    'no_alias_functions' => true,
+    'no_alias_language_construct_call' => true,
+    'no_alternative_syntax' => true,
+    'no_binary_string' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_closing_tag' => true,
+    'no_empty_phpdoc' => true,
+    'no_empty_statement' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'extra',
+            'throw',
+            'use',
+        ],
+    ],
+    'no_leading_import_slash' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_mixed_echo_print' => [
+        'use' => 'echo',
+    ],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'no_multiple_statements_per_line' => true,
+    'no_short_bool_cast' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'no_space_around_double_colon' => true,
+    'no_spaces_after_function_name' => true,
+    'no_spaces_around_offset' => [
+        'positions' => ['inside', 'outside'],
+    ],
+    'no_superfluous_phpdoc_tags' => [
+        'allow_mixed' => true,
+        'allow_unused_params' => true,
+    ],
+    'no_trailing_comma_in_singleline' => true,
+    'no_trailing_whitespace' => true,
+    'no_trailing_whitespace_in_comment' => true,
+    'no_unneeded_control_parentheses' => [
+        'statements' => ['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield'],
+    ],
+    'no_unneeded_braces' => true,
+    'no_unreachable_default_argument_value' => true,
+    'no_unset_cast' => true,
+    'no_unused_imports' => true,
+    'no_useless_return' => true,
+    'no_whitespace_before_comma_in_array' => true,
+    'no_whitespace_in_blank_line' => true,
+    'normalize_index_brace' => true,
+    'not_operator_with_successor_space' => true,
+    'nullable_type_declaration' => true,
+    'nullable_type_declaration_for_default_null_value' => true,
+    'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']],
+    'ordered_interfaces' => true,
+    'ordered_traits' => true,
+    'phpdoc_align' => [
+        'align' => 'left',
+        'spacing' => [
+            'param' => 2,
+        ],
+    ],
+    'phpdoc_indent' => true,
+    'phpdoc_inline_tag_normalizer' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_no_package' => true,
+    'phpdoc_no_useless_inheritdoc' => true,
+    'phpdoc_order' => [
+        'order' => ['param', 'return', 'throws'],
+    ],
+    'phpdoc_scalar' => true,
+    'phpdoc_separation' => [
+        'groups' => [
+            ['deprecated', 'link', 'see', 'since'],
+            ['author', 'copyright', 'license'],
+            ['category', 'package', 'subpackage'],
+            ['property', 'property-read', 'property-write'],
+            ['param', 'return'],
+        ],
+    ],
+    'phpdoc_single_line_var_spacing' => true,
+    'phpdoc_summary' => false,
+    'phpdoc_tag_type' => [
+        'tags' => [
+            'inheritdoc' => 'inline',
+        ],
+    ],
+    'phpdoc_to_comment' => false,
+    'phpdoc_trim' => true,
+    'phpdoc_types' => true,
+    'phpdoc_var_without_name' => true,
+    'psr_autoloading' => false,
+    'return_type_declaration' => ['space_before' => 'none'],
+    'self_accessor' => false,
+    'self_static_accessor' => true,
+    'short_scalar_cast' => true,
+    'simplified_null_return' => false,
+    'single_blank_line_at_eof' => true,
+    'single_class_element_per_statement' => [
+        'elements' => ['const', 'property'],
+    ],
+    'single_import_per_statement' => true,
+    'single_line_after_imports' => true,
+    'single_line_comment_style' => [
+        'comment_types' => ['hash'],
+    ],
+    'single_quote' => true,
+    'single_space_around_construct' => true,
+    'space_after_semicolon' => true,
+    'spaces_inside_parentheses' => true,
+    'standardize_not_equals' => true,
+    'statement_indentation' => true,
+    'switch_case_semicolon_to_colon' => true,
+    'switch_case_space' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+    'trim_array_spaces' => true,
+    'type_declaration_spaces' => true,
+    'types_spaces' => true,
+    'unary_operator_spaces' => true,
+    'visibility_required' => [
+        'elements' => ['method', 'property'],
+    ],
+    'whitespace_after_comma_in_array' => true,
+    'yoda_style' => [
+        'always_move_variable' => false,
+        'equal' => false,
+        'identical' => false,
+        'less_and_greater' => false,
+    ],
+
+    // Laravel
+    'Laravel/laravel_phpdoc_alignment' => true,
+];
+
+$finder = Finder::create()
+    ->in([
+        __DIR__.'/app',
+        __DIR__.'/config',
+        __DIR__.'/database',
+        __DIR__.'/public',
+        __DIR__.'/resources',
+        __DIR__.'/routes',
+        __DIR__.'/tests',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+$config = new Config();
+
+return $config
+    ->registerCustomFixers(new Fixers())
+    ->setFinder($finder)
+    ->setParallelConfig(ParallelConfigFactory::detect())
+    ->setRules($rules)
+    ->setRiskyAllowed(true)
+    ->setUsingCache(true);

--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@
 * Run DB migration scripts only on initial setup and after creating new migrations `sail migrate`
 * View the project in your browser at http://localhost:80
 
+## Project Linting
+* Navigate to the project directory and run `composer lint`
+
 ## Shutting down the project
 - To stop the containers run `sail down`

--- a/app/Fixers.php
+++ b/app/Fixers.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer: custom fixers.
+ *
+ * (c) 2018 Kuba Werłos
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace App;
+
+use PhpCsFixer\Fixer\FixerInterface;
+
+/**
+ * @implements \IteratorAggregate<FixerInterface>
+ */
+final class Fixers implements \IteratorAggregate
+{
+    /**
+     * @return \Generator<FixerInterface>
+     */
+    public function getIterator(): \Generator
+    {
+        $classNames = [];
+        foreach (new \DirectoryIterator(__DIR__.'/Fixers') as $fileInfo) {
+            $fileName = $fileInfo->getBasename('.php');
+            if (\in_array($fileName, ['.', '..', 'AbstractFixer', 'AbstractTypesFixer', 'DeprecatingFixerInterface'], true)) {
+                continue;
+            }
+            $classNames[] = __NAMESPACE__.'\\Fixers\\'.$fileName;
+        }
+
+        \sort($classNames);
+
+        foreach ($classNames as $className) {
+            $fixer = new $className();
+            \assert($fixer instanceof FixerInterface);
+
+            yield $fixer;
+        }
+    }
+}

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Fixers;
+
+use PhpCsFixer\DocBlock\TypeExpression;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+/*
+ * Some code in this file is part of PHP CS Fixer.
+ *
+ * Copyright (c) 2012-2022 Fabien Potencier, Dariusz Rumiński
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+class LaravelPhpdocAlignmentFixer implements FixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Laravel/laravel_phpdoc_alignment';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([T_DOC_COMMENT]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; $index--) {
+            if (! $tokens[$index]->isGivenKind([\T_DOC_COMMENT])) {
+                continue;
+            }
+
+            $newContent = preg_replace_callback(
+                '/(?P<tag>@param)\s+(?P<hint>(?:'.TypeExpression::REGEX_TYPES.')?)\s+(?P<var>(?:&|\.{3})?\$\S+)/ux',
+                fn ($matches) => $matches['tag'].'  '.$matches['hint'].'  '.$matches['var'],
+                $tokens[$index]->getContent()
+            );
+
+            if ($newContent == $tokens[$index]->getContent()) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $newContent]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('@param and type definition must be followed by two spaces.', []);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return -42;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -18,7 +18,7 @@ class HandleInertiaRequests extends Middleware
     /**
      * Determine the current asset version.
      */
-    public function version(Request $request): string|null
+    public function version(Request $request): ?string
     {
         return parent::version($request);
     }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,14 @@
         ],
         "lint": [
             "./vendor/bin/php-cs-fixer fix -vvv --show-progress=dots"
+        ],
+        "lint-sniff": [
+            "./vendor/bin/php-cs-fixer fix -vvv --dry-run --show-progress=dots"
         ]
+    },
+    "scripts-descriptions": {
+        "lint": "Perform code style fixes using php-cs-fixer",
+        "lint-sniff": "Recommend code style fixes using php-cs-fixer"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "friendsofphp/php-cs-fixer": "^3.58",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.29",
         "mockery/mockery": "^1.6",
@@ -50,6 +51,9 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
+        ],
+        "lint": [
+            "./vendor/bin/php-cs-fixer fix -vvv --show-progress=dots"
         ]
     },
     "extra": {

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -13,47 +13,47 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+        ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+        ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+        ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.store');
+        ->name('password.store');
 });
 
 Route::middleware('auth')->group(function () {
     Route::get('verify-email', EmailVerificationPromptController::class)
-                ->name('verification.notice');
+        ->name('verification.notice');
 
     Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
 
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+        ->name('password.confirm');
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });


### PR DESCRIPTION
This PR implements the Laravel code standards (from Laravel Pint) as a standard php-cs-fixer config file that can be used directly within the IDE to enforce code standards within the IDE.

Code Standards can also be manually applied by navigating to the project directory and running `composer lint`.

Alternatively, you could just add Laravel Pint to the project BUT your IDE cannot enforce the code standard rules from Laravel Pint directly since they are buried inside the Pint package.