### PR TITLE
Linter ADR: Laravel Backend Static Analysis (phpstan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@
 * Run DB migration scripts only on initial setup and after creating new migrations `sail migrate`
 * View the project in your browser at http://localhost:80
 
+## Project Static Analysis
+* Navigate to the project directory and run `composer analyse`
+
 ## Shutting down the project
 - To stop the containers run `sail down`

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<\Illuminate\Contracts\Validation\Rule|string>|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -11,7 +11,7 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<\Illuminate\Contracts\Validation\Rule|string>|string>
      */
     public function rules(): array
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use HasFactory, Notifiable;
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "larastan/larastan": "^2.0",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.29",
         "mockery/mockery": "^1.6",
@@ -50,7 +51,21 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
+        ],
+        "analyse": [
+            "./vendor/bin/phpstan analyse -c phpstan.neon"
+        ],
+        "analyse-baseline": [
+            "./vendor/bin/phpstan analyse -c phpstan.neon --generate-baseline"
+        ],
+        "analyse-cache-clear": [
+            "./vendor/bin/phpstan clear-result-cache"
         ]
+    },
+    "scripts-descriptions": {
+        "analyse": "Perform static analysis using phpstan",
+        "analyse-baseline": "Generate new static analysis baseline using phpstan",
+        "analyse-cache-clear": "Clear static analysis cache using phpstan"
     },
     "extra": {
         "laravel": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: routes/console.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,26 @@
+# Copy entire file to "phpstan.neon" if you need to make local changes
+includes:
+    - phpstan-baseline.neon
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+
+    paths:
+        - app
+        - config
+        - database
+        - public
+        - resources
+        - routes
+        - tests
+
+    # The level 9 is the highest level
+    level: 5
+
+    #ignoreErrors:
+    #    - '#PHPDoc tag @var#'
+
+    #excludePaths:
+    #    - ./*/*/FileToBeExcluded.php
+
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,30 @@
+# Copy entire file to "phpstan.neon" if you need to make local changes
+includes:
+    - phpstan-baseline.neon
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+
+    # Increase this value to shorten the time it takes to run PHPStan
+    parallel:
+        maximumNumberOfProcesses: 1
+
+    paths:
+        - app
+        - config
+        - database
+        - public
+        - resources
+        - routes
+        - tests
+
+    # The level 9 is the highest level
+    level: 7
+
+    #ignoreErrors:
+    #    - '#PHPDoc tag @var#'
+
+    #excludePaths:
+    #    - ./*/*/FileToBeExcluded.php
+
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'


### PR DESCRIPTION
This PR implements the Laravel static analysis (from Larastan) as a standard phpstan config file that can be used directly within the IDE to perform static analysis within the IDE.

Static Analysis can also be manually performed by navigating to the project directory and running `composer analyse`.

Alternatively, you could just add Larastan to the project BUT your IDE cannot leverage the phpstan rules from Larastan directly since they are buried inside the Larastan package.